### PR TITLE
Modernize for current Nim and drop deprecated threadpool

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,12 +1,20 @@
 name: CI
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
-  build:
+  test:
     runs-on: ubuntu-latest
+    continue-on-error: ${{ matrix.nim == 'devel' }}
+    strategy:
+      fail-fast: false
+      matrix:
+        nim: ['1.6.x', '2.0.x', '2.2.x', 'devel']
     steps:
-      - uses: actions/checkout@v1
-      - name: docker compose up and test
-        run: |
-          make docker-test
+      - uses: actions/checkout@v6
+      - uses: jiro4989/setup-nim-action@v2
+        with:
+          nim-version: ${{ matrix.nim }}
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Run tests
+        run: nimble test -y

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ format:
 
 .PHONY: docker-test
 docker-test:
-	docker-compose \
+	docker compose \
 		-f tests/docker-compose.test.yml \
 		-p loki-test \
 		up \

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 Loki
 ----
-[![](https://github.com/beshrkayali/loki/workflows/CI/badge.svg)](https://github.com/beshrkayali/loki/actions?query=workflow%3AC)
+[![](https://github.com/beshrkayali/loki/workflows/CI/badge.svg)](https://github.com/beshrkayali/loki/actions?query=workflow%3ACI)
 
 
 **loki**: line oriented (k)ommand interpreter
@@ -45,7 +45,7 @@ myCmd.cmdLoop
 Compile with something like:
 
 ```sh
-nim c --threads:on cmd.nim
+nim c cmd.nim
 ```
 
 And an example run:
@@ -136,6 +136,12 @@ which can be helpful when debugging your code to see what's going on.
 
 
 ### Changelog
+
+### [Unreleased]
+- Remove deprecated `threadpool`; `cmdLoop` is now a plain blocking loop
+  (fixes a busy-wait that spun the CPU while idle)
+- No longer requires `--threads:on`
+- `cmdLoop` no longer takes an unused `intro` argument (use `newLoki(intro=...)`)
 
 ### [0.3.0] Apr 2021
 - Automatically generate TOC and help for handler commands

--- a/loki.nimble
+++ b/loki.nimble
@@ -16,3 +16,4 @@ requires "nim >= 1.0.0"
 
 task test, "Run the unit tests":
   exec "nim r --hints:off tests/test.nim"
+  exec "nim r --hints:off tests/test_core.nim"

--- a/loki.nimble
+++ b/loki.nimble
@@ -1,7 +1,7 @@
 # Package
 
 version       = "0.3.0"
-author        = "Beshr Kayali"
+author        = "Beshr Kayali Reinholdsson"
 description   = "A small library for writing cli programs in Nim."
 license       = "Zlib"
 srcDir        = "src"
@@ -10,3 +10,9 @@ srcDir        = "src"
 # Dependencies
 
 requires "nim >= 1.0.0"
+
+
+# Tasks
+
+task test, "Run the unit tests":
+  exec "nim r --hints:off tests/test.nim"

--- a/src/loki.nim
+++ b/src/loki.nim
@@ -47,18 +47,12 @@
 ## myCmd.cmdLoop
 ## ```
 
-import os
-import macros
-import rdstdin
-import options
-import strutils
-import sequtils
-import threadpool
+import std/[macros, rdstdin, options, strutils, sequtils]
 
 
 const PROMPT = "(loki) "
 
-type Line* = ref object of RootObj
+type Line* = ref object
   command*: string
   args*: Option[seq[string]]
   text*: string
@@ -153,26 +147,14 @@ proc oneCmd(loki: Loki, line_text: string): bool =
   return loki.handler(newLine(line_text))
 
 
-proc cmdLoop*(loki: Loki, intro: string = "") =
-  var lineFlowVar: FlowVar[string]
-
-  lineFlowVar = spawn input loki
-
+proc cmdLoop*(loki: Loki) =
   write(stdout, loki.intro)
 
-  var stop: bool = false;
+  var stop = false
 
   while not stop:
-    if lineFlowVar.isReady():
-      # precmd
-      stop = loki.oneCmd(^lineFlowVar)
-      # postcmd
-
-      # Respawn
-      if not stop:
-        # FIXME: Hack to prevent eager spawning
-        echo("")
-        lineFlowVar = spawn input loki
+    # precmd / postcmd hooks would go here
+    stop = loki.oneCmd(loki.input())
 
 
 # Macros

--- a/tests/docker-compose.test.yml
+++ b/tests/docker-compose.test.yml
@@ -1,12 +1,9 @@
-version: "3.7"
-
 services:
   sut:
-    image: nimlang/nim:1.0.0-regular
+    image: nimlang/nim:2.2.0
     stdin_open: true
     working_dir: /usr/src/app
     tty: true
-    command: nimble test -Y
+    command: sh -c "git config --global --add safe.directory /usr/src/app && nimble test -Y"
     volumes:
       - ../:/usr/src/app
-

--- a/tests/test.nim.cfg
+++ b/tests/test.nim.cfg
@@ -1,1 +1,0 @@
---threads:on

--- a/tests/test_core.nim
+++ b/tests/test_core.nim
@@ -1,0 +1,64 @@
+import std/unittest
+
+include "../src/loki.nim"
+
+suite "newLoki":
+  test "applies defaults":
+    let l = newLoki(proc(line: Line): bool = false)
+    check l.prompt == "(loki) "
+    check l.intro == "\n" # "" & "\n"
+    check l.lastcmd == ""
+    check l.doc_header == "Documented commands (type help <topic>):"
+
+  test "keeps a custom intro and prompt":
+    let l = newLoki(proc(line: Line): bool = false, intro = "Welcome", prompt = "> ")
+    check l.intro == "Welcome\n"
+    check l.prompt == "> "
+
+suite "newLine":
+  test "takes the command from the first token and keeps the full text":
+    check newLine("greet world foo").command == "greet"
+    check newLine("greet world foo").text == "greet world foo"
+    check newLine("solo").command == "solo"
+    check newLine("").command == ""
+
+var lastCalled: string
+
+loki(testHandler, line):
+  do_greet name:
+    lastCalled = "greet"
+  do_EOF:
+    lastCalled = "eof"
+    return true
+  default:
+    lastCalled = "default"
+
+suite "oneCmd dispatch":
+  test "routes a known command to its handler":
+    let l = newLoki(testHandler)
+    lastCalled = ""
+    discard l.oneCmd("greet there")
+    check lastCalled == "greet"
+
+  test "routes an unknown command to default":
+    let l = newLoki(testHandler)
+    lastCalled = ""
+    discard l.oneCmd("nope")
+    check lastCalled == "default"
+
+  test "EOF handler can stop the loop":
+    let l = newLoki(testHandler)
+    check l.oneCmd("EOF") == true
+
+  test "an empty line repeats the last command":
+    let l = newLoki(testHandler)
+    discard l.oneCmd("greet there")
+    lastCalled = ""
+    discard l.oneCmd("") # repeats "greet there"
+    check lastCalled == "greet"
+
+  test "an empty line with no history runs the empty command":
+    let l = newLoki(testHandler)
+    lastCalled = ""
+    discard l.oneCmd("") # lastcmd is "" -> no repeat -> falls to default
+    check lastCalled == "default"


### PR DESCRIPTION
Modernizes loki for current Nim (while still supporting back to 1.0), no new deps.

- Replace deprecated `threadpool` with a plain blocking REPL loop.
- Add some new unit tests for newLoki, newLine, and command dispatch
- CI improvements